### PR TITLE
careerhub sa의 자격증명 방법을 pod identity에서 irsa로 변경

### DIFF
--- a/core/_modules/role_for_sa/main.tf
+++ b/core/_modules/role_for_sa/main.tf
@@ -27,6 +27,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
+  count      = var.policy_arn == "" ? 0 : 1
   role       = aws_iam_role.this.name
   policy_arn = var.policy_arn
 }

--- a/core/_modules/role_for_sa/variables.tf
+++ b/core/_modules/role_for_sa/variables.tf
@@ -15,5 +15,6 @@ variable "service_account_name" {
 }
 
 variable "policy_arn" {
-  type = string
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
golang mongodb driver가 pod identity를 통해 얻은 자격증명을 지원하지 않는 이슈로 irsa로 변경 그 외 mongodb_database_user의 권한 범위 수정